### PR TITLE
Using json Tag as fallback for db Tag on getFields

### DIFF
--- a/sqm.go
+++ b/sqm.go
@@ -52,9 +52,15 @@ func getFields(rT reflect.Type) []field {
 
 	for j := 0; j < rT.NumField(); j++ {
 		f := rT.Field(j)
+
 		db, exists := f.Tag.Lookup("db")
 		if exists {
 			fs = append(fs, field{f, db})
+		} else {
+			db, exists := f.Tag.Lookup("json")
+			if exists {
+				fs = append(fs, field{f, db})
+			}
 		}
 	}
 


### PR DESCRIPTION
Today we have to use a model like:

```go
FooBar string `db:"foo_bar" json:"foo_bar"`
```

If `db` tag was not set on model, `sqm` uses `json` as fallback